### PR TITLE
Fix `cp` command on OSX

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -23,8 +23,8 @@ tasks:
     desc: Initialize configuration files
     dir: "{{.TEMPLATE_DIR}}"
     cmds:
-      - cp --no-clobber vars/addons.sample.yaml vars/addons.yaml
-      - cp --no-clobber vars/config.sample.yaml vars/config.yaml
+      - cp -n vars/addons.sample.yaml vars/addons.yaml
+      - cp -n vars/config.sample.yaml vars/config.yaml
       - cmd: echo "=== Configuration files copied ==="
         silent: true
       - cmd: echo "Proceed with updating the configuration files..."


### PR DESCRIPTION
The `--no-clobber` option is non-POSIX, but GNU-specific. The `-n` should work the same in Linux and OSX.